### PR TITLE
Some bug fixes and ability to enable/disable individual services in a servicegroup

### DIFF
--- a/lib/netscaler/cli.rb
+++ b/lib/netscaler/cli.rb
@@ -214,13 +214,14 @@ module Netscaler
             end
           end
         end
-        string :servername, "The name of the server to scope this command to" do
+        string :servername, "The name of the server that an individual service runs on (used when scoping the action to an individual service in a service group)." do
           depends_on :action
         end
-        string :port, "The service port to scope this command to" do
+        string :port, "The port number that an individual service in bound to (used when scoping the action to an individual service in a service group)." do
           depends_on :action
+          end
         end
-        string :delay, "The delay (in seconds) to wait before service transitions to Out of Service" do
+        string :delay, "The delay (in seconds) to wait before disabled services transition to Out of Service. Default is 0 seconds (immediately)." do
           depends_on :action
           default "0"
         end

--- a/lib/netscaler/cli.rb
+++ b/lib/netscaler/cli.rb
@@ -214,6 +214,16 @@ module Netscaler
             end
           end
         end
+        string :servername, "The name of the server to scope this command to" do
+          depends_on :action
+        end
+        string :port, "The service port to scope this command to" do
+          depends_on :action
+        end
+        string :delay, "The delay (in seconds) to wait before service transitions to Out of Service" do
+          depends_on :action
+          default "0"
+        end
         arguments do
           count 0..1 #:at_least => 0, :at_most => 1
           metaname '[SERVICEGROUP]'

--- a/lib/netscaler/servicegroup/request.rb
+++ b/lib/netscaler/servicegroup/request.rb
@@ -5,14 +5,17 @@ module Netscaler::ServiceGroup
   class Request < Netscaler::BaseRequest
     def enable(service, options)
       params = { :servicegroupname => service }
+      [:servername, :port].each do |option|
+        params[option] = options[option] if options[option]
+      end
       send_request('enableservicegroup', params)
     end
 
     def disable(servicegroup, options)
-      params = { 
-        :servicegroupname => servicegroup, 
-        :delay => 0 
-      }
+      params = { :servicegroupname => servicegroup }
+      [:servername, :port, :delay].each do |option|
+        params[option] = options[option] if options[option]
+      end
       send_request('disableservicegroup', params)
     end
 

--- a/lib/netscaler/servicegroup/request.rb
+++ b/lib/netscaler/servicegroup/request.rb
@@ -10,7 +10,7 @@ module Netscaler::ServiceGroup
 
     def disable(servicegroup, options)
       params = { 
-        :servicegroupname => servicename, 
+        :servicegroupname => servicegroup, 
         :delay => 0 
       }
       send_request('disableservicegroup', params)

--- a/lib/netscaler/servicegroup/response.rb
+++ b/lib/netscaler/servicegroup/response.rb
@@ -60,7 +60,6 @@ module Netscaler::ServiceGroup
         @ip_address = @ip_address[index]
         @state = @state[index]
         @port = @port[index]
-        @type = @type[index]
       end
     end
 

--- a/spec/netscaler/cli_spec.rb
+++ b/spec/netscaler/cli_spec.rb
@@ -161,7 +161,7 @@ module Netscaler
         res.subresults[0].args[0].should eql('a-service-group')
       end
 
-      it "should succed in setting the vserver name" do
+      it "should succeed in setting the vserver name" do
         res = parse('-n', 'else', 'servicegroup', '-a', 'bind', '-v', 'blah', 'a-service-group')
         res.subresults[0][:vserver].should eql('blah')
       end
@@ -174,6 +174,29 @@ module Netscaler
       it "should set the default action to status" do
         res = parse('-n', 'else', 'servicegroup', 'a-service-group')
         res.subresults[0][:action].should eql(:status)
+      end
+
+      describe "scoping to an individual service" do
+        before :each do 
+          @res = parse('-n', 'else', 'servicegroup', '-a', 'enable', 'a-service-group', '-s', 'a-server-name', '-p', '8080', '-d', '180')
+        end
+        
+        it "should set the servername to a-server-name" do
+          @res.subresults[0][:servername].should eql('a-server-name')
+        end
+        
+        it "should set the port to 8080" do
+          @res.subresults[0][:port].should eql('8080')
+        end
+        
+        it "should set the delay to 180" do
+          @res.subresults[0][:delay].should eql('180')
+        end
+        
+        it "should set the delay to 0 if not specified" do
+          @res = parse('-n', 'else', 'servicegroup', '-a', 'enable', 'a-service-group', '-s', 'a-server-name', '-p', '8080')
+          @res.subresults[0][:delay].should eql('0')
+        end
       end
     end
 


### PR DESCRIPTION
I was doing some investigation into using the SOAP API to talk to Netscaler 8.1 at work and found your gem.  It does most of what I need so I thought I'd use it rather than re-inventing the wheel.  There were a couple of immediate (simple) bugs I found and then I needed to expose the ability to enable/disable individual services in a service group with an optional delay (which you hadn't got around to doing yet).

Let me know if there is anything you would want me to change.  This is my first ever pull request.  I might add more API features as I need them.  Not sure how you feel about the level of argument checking for the nre servicegroup arguments.  For now I didn't put too much around servername and port as the server will tell you if you missed one of them (both are required if you supplied one).  I also didn't put checks to restrict which actions they can be used with.  I figure I might expand their use later so didn't restrict their use for now.
